### PR TITLE
Fixed tooltips on windows that had not yet been opened.

### DIFF
--- a/dockbarx/dockbar.py
+++ b/dockbarx/dockbar.py
@@ -876,6 +876,7 @@ class DockBar():
     def __make_groupbutton(self, identifier=None, desktop_entry=None,
                          pinned=False, index=None, window=None):
         group = Group(self, identifier, desktop_entry, pinned)
+        group.update_name()
         if window is not None:
             # Windows are added here instead of later so that
             # overflow manager knows if the button should be


### PR DESCRIPTION
I noticed that after enabling/disabling the setting "Show tooltip when no window is opening", tooltips would appear for all unopened windows. However, after restarting DockbarX, or performing a refresh, this would no longer work.

After digging through a little, I found that groups are given their tooltip through group.update_tooltip(), which is called by group.update_name(). This is called whenever a window is opened, closed, or has a media player attached/detached. It is also called whenever the "Show tooltip when no window is opening" setting is changed.

It was not, however called for unopened groups at startup. This one line fix updates the names of groups upon creation, and solves the issue for me.