### PR TITLE
fix the visibility bugs of arrow buttons

### DIFF
--- a/dockbarx/dockbar.py
+++ b/dockbarx/dockbar.py
@@ -314,6 +314,7 @@ class GroupList(list):
             self.overflow_set = 0
         if not groups:
             # No buttons are shown on the screen, no size overflow.
+            self.hide_arrow_buttons()
             return
         max_size = self.calculate_max_size()
         if max_size < self.button_size:
@@ -834,6 +835,7 @@ class DockBar():
             return
         for group in self.groups:
             group.desktop_changed()
+        self.groups.manage_size_overflow()    
 
 
     #### Groupbuttons


### PR DESCRIPTION
This patch fixed 2 bugs.
1. If there was no window when dockbarx started, the arrow buttons were still visible.
2. The change of desktop or workspace didn't affect the visibility of arrow buttons.

And this patch should be suitable for the gtk3 branch, but I haven't tested yet.
  