### PR TITLE
Fix identifier choice when no name is immediately present

### DIFF
--- a/dockbarx/dockbar.py
+++ b/dockbarx/dockbar.py
@@ -907,7 +907,7 @@ class DockBar():
             res_class = window.get_class_group().get_res_class().lower()
             res_name = window.get_class_group().get_name().lower()
         if window.has_name():
-            identifier = res_class or res_name or window.get_name().lower()
+            fallback = window.get_name().lower()
         else:
             #in case window has no name - issue with Spotify
             pid = window.get_pid()
@@ -917,9 +917,10 @@ class DockBar():
                 raise
             cmd = f.readline()
             if "/" in cmd:
-                identifier = cmd.split("/")[-1]
+                fallback = cmd.split("/")[-1]
             else:
-                identifier = cmd
+                fallback = cmd
+        identifier = res_class or res_name or fallback
         # Special cases
         if identifier in SPECIAL_RES_CLASSES:
             identifier = SPECIAL_RES_CLASSES[identifier]

--- a/dockbarx/dockbar.py
+++ b/dockbarx/dockbar.py
@@ -915,7 +915,7 @@ class DockBar():
                 f = open("/proc/"+str(pid)+"/cmdline", "r")
             except:
                 raise
-            cmd = f.readline()
+            cmd = f.readline().split("\0")[0]
             if "/" in cmd:
                 fallback = cmd.split("/")[-1]
             else:


### PR DESCRIPTION
This pull fixes a problem which caused several windows, such as `mpv` video windows, to not show up in dock under certain circumstances.  The underlying reason for the issue was that `Gtk.IconTheme.has_icon` did not accept strings with null bytes, and the cmdline files use null bytes to separate arguments.

26570a7 makes behavior in the absense of a window title more like when there is one.  This fixed the problem for me, although it does not address the problem of null bytes, just makes it less likely to come up.

d533b05 does what I think is the right behavior regarding null bytes.
  