### PR TITLE
Removes strategy to remove strut when screen exist at the same side of the dockbarx

### DIFF
--- a/dockx
+++ b/dockx
@@ -781,25 +781,12 @@ class DockX(CairoDockX):
         mx, my, mw, mh = s.get_monitor_geometry(self.monitor)
         if self.globals.settings["dock/position"] == "left":
             strut = [x + w, 0, 0, 0, y, y + h - 1, 0, 0, 0, 0, 0, 0]
-            # Make sure that there's no monitor on the left side of this one.
-            if s.get_monitor_at_point(mx - 5, y + h / 2) != self.monitor:
-                set_strut = False
         elif self.globals.settings["dock/position"] == "right":
             strut = [0, sw - x, 0, 0, 0, 0, y, y + h - 1, 0, 0, 0, 0]
-            if s.get_monitor_at_point(mx + mw + 5, y + h / 2) != self.monitor:
-                set_strut = False
         elif self.globals.settings["dock/position"] == "top":
             strut = [0, 0, y + h, 0, 0, 0, 0, 0, x, x + w - 1, 0, 0]
-            if s.get_monitor_at_point(x + w / 2, my - 5) != self.monitor:
-                set_strut = False
         else:
             strut = [0, 0, 0, sh - y, 0, 0, 0, 0, 0, 0, x, x + w - 1]
-            if s.get_monitor_at_point(x + w / 2, my + mh + 5) != self.monitor:
-                set_strut = False
-        if not set_strut:
-            self.window.property_delete("_NET_WM_STRUT")
-            self.window.property_delete("_NET_WM_STRUT_PARTIAL")
-            return
         self.window.property_change("_NET_WM_STRUT", "CARDINAL", 32, 
                                     gtk.gdk.PROP_MODE_REPLACE, strut[:4])  
         self.window.property_change("_NET_WM_STRUT_PARTIAL", "CARDINAL", 


### PR DESCRIPTION
Without struts, the fullscreen windows overlap with dockbarx.

For example, if you have SCREEN-LEFT and SCREEN-RIGHT, with dockbarx in SCREEN-RIGHT, in position "left", it will overlap with existing window. I don't really understand what benefit the code I removed had, so even if I can understand this pull request won't be accepted, I create it to have a discussion with the dockbarx maintainers.

