### PR TITLE
Support for the XDG Base Directory Specification

### DIFF
--- a/dbx_preference
+++ b/dbx_preference
@@ -1427,13 +1427,12 @@ class PrefDialog():
             self.globals.update_colors(None)
 
     def __find_themes(self):
-        # Reads the themes from /usr/share/dockbarx/themes and
-        # ~/.dockbarx/themes and returns a dict of the theme names
-        # and paths so that a theme can be loaded.
+        # ${XDG_DATA_HOME:-$HOME/.local/share}/dockbarx/themes
+        # and returns a dict of the theme names and paths so
+        # that a theme can be loaded.
         themes = {}
         theme_paths = []
-        homeFolder = os.path.expanduser("~")
-        theme_folder = homeFolder + "/.dockbarx/themes"
+        theme_folder = os.path.join(get_app_homedir(), "themes")
         dirs = ["/usr/share/dockbarx/themes", theme_folder]
         for dir in dirs:
             if os.path.exists(dir) and os.path.isdir(dir):
@@ -1451,7 +1450,7 @@ class PrefDialog():
                 name = str(name)
                 themes[name] = theme_path
         if not themes:
-            messag = _("No working themes found in /usr/share/dockbarx/themes or ~/.dockbarx/themes")
+            messag = _("No working themes found in /usr/share/dockbarx/themes or ${XDG_DATA_HOME:-$HOME/.local/share}/dockbarx/themes")
             flags = gtk.DIALOG_MODAL | gtk.DIALOG_DESTROY_WITH_PARENT
             md = gtk.MessageDialog(self.dialog,
                                    flags,

--- a/dbx_preference
+++ b/dbx_preference
@@ -1427,6 +1427,7 @@ class PrefDialog():
             self.globals.update_colors(None)
 
     def __find_themes(self):
+        # Reads the themes from /usr/share/dockbarx/themes and
         # ${XDG_DATA_HOME:-$HOME/.local/share}/dockbarx/themes
         # and returns a dict of the theme names and paths so
         # that a theme can be loaded.

--- a/dockbarx/applets.py
+++ b/dockbarx/applets.py
@@ -26,6 +26,7 @@ import weakref
 import gobject
 from dbus.mainloop.glib import DBusGMainLoop
 from log import logger
+from dockbarx.common import get_app_homedir
 
 GCONF_CLIENT = gconf.client_get_default()
 GCONF_DIR = "/apps/dockbarx"
@@ -38,13 +39,13 @@ class DockXApplets():
         self.find_applets()
 
     def find_applets(self):
-        # Reads the themes from /usr/share/dockbarx/themes/dock_themes and
-        # ~/.dockbarx/themes/dock_themes and returns a dict
-        # of the theme file names and paths so that a theme can be loaded
+        # Reads the applets from /usr/share/dockbarx/applets and
+        # ${XDG_DATA_HOME:-$HOME/.local/share}/dockbarx/applets
+        # and returns a dict of the applets file names and paths so that a
+        # applet can be loaded
         self.applets = {}
-        home_folder = os.path.expanduser("~")
-        theme_folder = home_folder + "/.dockbarx/applets"
-        dirs = ["/usr/share/dockbarx/applets", theme_folder]
+        applets_folder = os.path.join(get_app_homedir(), "applets")
+        dirs = ["/usr/share/dockbarx/applets", applets_folder]
         for dir in dirs:
             if not(os.path.exists(dir) and os.path.isdir(dir)):
                 continue

--- a/dockbarx/common.py
+++ b/dockbarx/common.py
@@ -73,6 +73,31 @@ def check_program(name):
         prog = os.path.join(dir, name)
         if os.path.exists(prog): return prog
 
+def get_app_homedir():
+    homedir = os.environ['HOME']
+    default = os.path.join(homedir, '.local', 'share')
+    appdir = os.path.join(
+	os.getenv('XDG_DATA_HOME', default),
+	'dockbarx'
+    )
+    """
+    Migration Path
+    From "$HOME/.dockbarx" to "${XDG_DATA_HOME:-$HOME/.local/share}/dockbarx"
+    """
+    old_appdir = os.path.join(homedir, '.dockbarx')
+    if os.path.exists(old_appdir) and os.path.isdir(old_appdir):
+	try:
+	    os.rename(old_appdir, appdir)
+	except OSError:
+	    sys.stderr.write('Could not move dir "%s" to "%s". \
+			     Move the contents of "%s" to "%s" manually \
+			     and then remove the first location.'
+			     % (old_appdir, appdir, old_appdir, appdir))
+    """
+    End Migration Path
+    """
+    return appdir
+
 class Connector():
     """A class to simplify disconnecting of signals"""
     def __init__(self):

--- a/dockbarx/dockbar.py
+++ b/dockbarx/dockbar.py
@@ -1322,8 +1322,7 @@ class DockBar():
             self.__add_window(window)
 
     def edit_launcher(self, path, identifier):
-        launcher_dir = os.path.join(os.path.expanduser("~"),
-                                    ".dockbarx", "launchers")
+        launcher_dir = os.path.join(get_app_homedir(), "launchers")
         if not os.path.exists(launcher_dir):
             os.makedirs(launcher_dir)
         if path:

--- a/dockbarx/log.py
+++ b/dockbarx/log.py
@@ -24,8 +24,10 @@ import os
 logging.basicConfig(format="%(message)s", level=logging.DEBUG)
 logger = logging.getLogger("DockbarX")
 
+from common import get_app_homedir
+
 def log_to_file():
-    log_dir = os.path.join(os.path.expanduser("~"), ".dockbarx", "log")
+    log_dir = os.path.join(get_app_homedir(), "log")
     if not os.path.exists(log_dir):
         os.makedirs(log_dir)
     log_file = os.path.join(log_dir, "dockbarx.log")

--- a/dockbarx/theme.py
+++ b/dockbarx/theme.py
@@ -27,6 +27,7 @@ import os
 import array
 from common import ODict
 from common import Globals
+from common import get_app_homedir
 from log import logger
 from PIL import Image
 
@@ -146,12 +147,12 @@ class Theme(gobject.GObject):
 
     def find_themes(self):
         # Reads the themes from /usr/share/dockbarx/themes and
-        # ~/.dockbarx/themes and returns a dict
-        # of the theme names and paths so that a theme can be loaded
+        # ${XDG_DATA_HOME:-$HOME/.local/share}/dockbarx/themes
+        # and returns a dict of the theme names and paths so
+        # that a theme can be loaded.
         themes = {}
         theme_paths = []
-        homeFolder = os.path.expanduser("~")
-        theme_folder = homeFolder + "/.dockbarx/themes"
+        theme_folder = os.path.join(get_app_homedir(), "themes")
         dirs = ["/usr/share/dockbarx/themes", theme_folder]
         for dir in dirs:
             if os.path.exists(dir) and os.path.isdir(dir):
@@ -171,11 +172,11 @@ class Theme(gobject.GObject):
             md = gtk.MessageDialog(None,
                 gtk.DIALOG_MODAL | gtk.DIALOG_DESTROY_WITH_PARENT,
                 gtk.MESSAGE_ERROR, gtk.BUTTONS_CLOSE,
-                _("No working themes found in /usr/share/dockbarx/themes or ~/.dockbarx/themes"))
+                _("No working themes found in /usr/share/dockbarx/themes or ${XDG_DATA_HOME:-$HOME/.local/share}/dockbarx/themes"))
             md.run()
             md.destroy()
             raise NoThemesError("No working themes found in " + \
-                        "/usr/share/dockbarx/themes or ~/.dockbarx/themes")
+                        "/usr/share/dockbarx/themes or ${XDG_DATA_HOME:-$HOME/.local/share}/dockbarx/themes")
         return themes
 
     def reload(self):
@@ -407,12 +408,12 @@ class PopupStyle(gobject.GObject):
 
     def find_styles(self):
         # Reads the styles from /usr/share/dockbarx/themes/popup_styles and
-        # ~/.dockbarx/themes/popup_styles and returns a dict
-        # of the style file names and paths so that a style can be loaded
+        # ${XDG_DATA_HOME:-$HOME/.local/share}/dockbarx/themes/popup_styles
+        # and returns a dict of the style file names and paths so that a
+        # style can be loaded
         styles = {}
         style_paths = []
-        homeFolder = os.path.expanduser("~")
-        style_folder = homeFolder + "/.dockbarx/themes/popup_styles"
+        style_folder = os.path.join(get_app_homedir(), "themes", "popup_styles")
         dirs = ["/usr/share/dockbarx/themes/popup_styles", style_folder]
         for dir in dirs:
             if os.path.exists(dir) and os.path.isdir(dir):
@@ -522,8 +523,7 @@ class PopupStyle(gobject.GObject):
         # For DockbarX preference. This function makes a dict of the names and
         # file names of the styles for all styles that can be opened correctly.
         styles = {}
-        home_folder = os.path.expanduser("~")
-        style_folder = home_folder + "/.dockbarx/themes/popup_styles"
+        style_folder = os.path.join(get_app_homedir(), "themes", "popup_styles")
         dirs = ["/usr/share/dockbarx/themes/popup_styles", style_folder]
         for dir in dirs:
             if os.path.exists(dir) and os.path.isdir(dir):
@@ -613,12 +613,12 @@ class DockTheme(gobject.GObject):
 
     def find_themes(self):
         # Reads the themes from /usr/share/dockbarx/themes/dock_themes and
-        # ~/.dockbarx/themes/dock_themes and returns a dict
-        # of the theme file names and paths so that a theme can be loaded
+        # ${XDG_DATA_HOME:-$HOME/.local/share}/dockbarx/themes/dock_themes
+        # and returns a dict of the theme file names and paths so that a
+        # theme can be loaded
         themes = {}
         theme_paths = []
-        homeFolder = os.path.expanduser("~")
-        theme_folder = homeFolder + "/.dockbarx/themes/dock"
+        theme_folder = os.path.join(get_app_homedir(), "themes", "dock")
         dirs = ["/usr/share/dockbarx/themes/dock", theme_folder]
         for dir in dirs:
             if os.path.exists(dir) and os.path.isdir(dir):
@@ -734,8 +734,7 @@ class DockTheme(gobject.GObject):
         # For DockbarX preference. This function makes a dict of the names and
         # file names of the themes for all themes that can be opened correctly.
         themes = {}
-        home_folder = os.path.expanduser("~")
-        theme_folder = home_folder + "/.dockbarx/themes/dock"
+        theme_folder = os.path.join(get_app_homedir(), "themes", "dock")
         dirs = ["/usr/share/dockbarx/themes/dock", theme_folder]
         for dir in dirs:
             if os.path.exists(dir) and os.path.isdir(dir):

--- a/dockx_applets/namebar_window_buttons.py
+++ b/dockx_applets/namebar_window_buttons.py
@@ -25,6 +25,7 @@ import wnck
 import gconf
 from tarfile import open as taropen
 from dockbarx.applets import DockXApplet, DockXAppletDialog
+from namebar import get_namebar_homedir
 
 VERSION = '0.1'
 
@@ -91,7 +92,7 @@ class PrefDialog():
         self.dialog = gtk.Dialog("WindowButtonApplet preferences")
         self.dialog.connect("response",self.dialog_close)
 
-        self.namebar= namebar
+        self.namebar = namebar
 
         try:
             ca = self.dialog.get_content_area()
@@ -204,12 +205,13 @@ class PrefDialog():
             GCONF_CLIENT.set_string("%s/custom_layout" % GCONF_DIR, text)
 
     def find_themes(self):
-        # Reads the themes from /usr/share/dockbarx/themes and ~/.dockbarx/themes
+        # Reads the themes from /usr/share/namebar/themes and
+        # ${XDG_DATA_HOME:-$HOME/.local/share}/namebar/themes
         # and returns a dict of the theme names and paths so that
         # a theme can be loaded
         themes = {}
         theme_paths = []
-        dirs = ["/usr/share/namebar/themes", "%s/.namebar/themes" % os.path.expanduser("~")]
+        dirs = ["/usr/share/namebar/themes", os.path.join(get_namebar_homedir(), "themes")]
         for dir in dirs:
             if os.path.exists(dir):
                 for f in os.listdir(dir):
@@ -223,10 +225,10 @@ class PrefDialog():
             md = gtk.MessageDialog(None,
                 gtk.DIALOG_MODAL | gtk.DIALOG_DESTROY_WITH_PARENT,
                 gtk.MESSAGE_ERROR, gtk.BUTTONS_CLOSE,
-                'No working themes found in "/usr/share/namebar/themes" or "~/.namebar/themes"')
+                'No working themes found in "/usr/share/namebar/themes" or "${XDG_DATA_HOME:-$HOME/.local/share}/namebar/themes"')
             md.run()
             md.destroy()
-            print 'Preference dialog error: No working themes found in "/usr/share/namebar/themes" or "~/.namebar/themes"'
+            print 'Preference dialog error: No working themes found in "/usr/share/namebar/themes" or "${XDG_DATA_HOME:-$HOME/.local/share}/namebar/themes"'
         return themes
 
     def change_theme(self, button=None):
@@ -461,12 +463,13 @@ class WindowButtonApplet(DockXApplet):
                     self.container.pack_end(pack_dict[item], False)
 
     def find_themes(self):
-        # Reads the themes from /usr/share/dockbarx/themes and ~/.dockbarx/themes
+        # Reads the themes from /usr/share/namebar/themes and
+        # ${XDG_DATA_HOME:-$HOME/.local/share}/namebar/themes
         # and returns a dict of the theme names and paths so that
         # a theme can be loaded
         themes = {}
         theme_paths = []
-        dirs = ["/usr/share/namebar/themes", "%s/.namebar/themes"%os.path.expanduser("~")]
+        dirs = ["/usr/share/namebar/themes", os.path.join(get_namebar_homedir(), "themes")]
         for dir in dirs:
             if os.path.exists(dir):
                 for f in os.listdir(dir):
@@ -480,10 +483,10 @@ class WindowButtonApplet(DockXApplet):
             md = gtk.MessageDialog(None,
                 gtk.DIALOG_MODAL | gtk.DIALOG_DESTROY_WITH_PARENT,
                 gtk.MESSAGE_ERROR, gtk.BUTTONS_CLOSE,
-                'No working themes found in "/usr/share/namebar/themes" or "~/.namebar/themes"')
+                'No working themes found in "/usr/share/namebar/themes" or "${XDG_DATA_HOME:-$HOME/.local/share}/namebar/themes"')
             md.run()
             md.destroy()
-            print 'No working themes found in "/usr/share/namebar/themes" or "~/.namebar/themes"'
+            print 'No working themes found in "/usr/share/namebar/themes" or "${XDG_DATA_HOME:-$HOME/.local/share}/namebar/themes"'
             sys.exit(1)
         return themes
 


### PR DESCRIPTION
Hey!

I would like to discuss and possible merge this request. The [XDG Base Dir Spec](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html) serves as a reference on how to split files from an application whose data is stored on a single dot dir on the user's home into three different categories: config, data and cache files. These can be configured by three environment variables.

| Variable  | Default value |
| ------------- | ------------- |
| XDG_CACHE_HOME | $HOME/.cache |
| XDG_CONFIG_HOME | $HOME/.config |
| XDG_DATA_HOME | $HOME/.local/share |

 For dockbarx, It could be like this:

| Old location  | New |
| ------------- | ------------- |
| $HOME/.dockbarx  | ${XDG_DATA_HOME:-$HOME/.local/share}/dockbarx  |
| $HOME/.namebar  | ${XDG_DATA_HOME:-$HOME/.local/share}/namebar  |

You already do some of this for configuration files, since you use gconf. Everything else (log, applets, themes) feels to me like user data, hence the decision.

There is an automated migration path, that renames the old location to the new. This can be tricky, since we could also run a "old config first, then the new one" where we check if "~/.dockbarx" exists; if it does, then we use this. Otherwise, use the new location. 

I should have opened a issue about this, but I forgot and I was already working on it =P
I still have to update the docs, so if you like this change, let me update it before the merge.