### PR TITLE
Make Super+Num minimise already-active window

### DIFF
--- a/dockbarx/dockbar.py
+++ b/dockbarx/dockbar.py
@@ -1898,8 +1898,13 @@ class DockBar():
             if not group.media_controls or not success:
                 group.action_launch_application()
         if len(windows) == 1:
-            # Just one window. Let's focus on it straight away.
-            windows[0].action_select_window()
+            # Just one window.
+            if windows[0].is_active_window:
+                # If it's already active, minimise it.
+                windows[0].action_minimize_window()
+            else:
+                # If it's inactive, let's show it.
+                windows[0].action_select_window()
 
     def __on_super_released(self, *args):
         # Break the signal connection to avoid multiple release calls.


### PR DESCRIPTION
On Windows, pressing the Super+Num shortcut for a program that has a single already-focused window will minimise that window. The shortcut can thus function as a toggle switch for activating/minimising the window. This is important enough to my workflow for managing windows that I added it to DockbarX. I've been using it on my system with the Xfce panel plugin and works as I want it to.

This is also the default behaviour in Plasma and Cinnamon as well as a similar launcher plugin for MATE.